### PR TITLE
added Width and Height sliders to group config

### DIFF
--- a/Components/IconViews/Bar/Config.xml
+++ b/Components/IconViews/Bar/Config.xml
@@ -1,7 +1,7 @@
 <Ui>
 
 	<Frame name="TellMeWhen_GM_Bar" inherits="TellMeWhen_OptionsModuleContainer" virtual="true">
-		<Size y="100"/>
+		<Size y="150"/>
 		<Frames>
 
 			<CheckButton parentKey="Icon" inherits="TellMeWhen_CheckTemplate">
@@ -137,6 +137,56 @@
 						self:SetWheelStep(0.5)
 
 						self:SetTextFormatter(TMW.C.Formatter.PIXELS, TMW.C.Formatter.F_0)
+					</OnLoad>
+				</Scripts>
+			</Slider>
+
+			<Slider parentKey="SizeX" inherits="TellMeWhen_SliderTemplate">
+				<Anchors>
+					<Anchor point="TOP" relativeKey="$parent.BorderIcon" relativePoint="BOTTOM"  y="-20"/>
+					<Anchor point="LEFT" relativeKey="$parent.BorderIcon" />
+					<Anchor point="RIGHT" relativeKey="$parent.BorderIcon" />
+					
+				</Anchors>
+				<Scripts>
+					<OnLoad>						
+						TMW:CInit(self)
+
+						self:SetTexts(TMW.L["UIPANEL_BAR_SIZE_X"], TMW.L["UIPANEL_BAR_SIZE_X_DESC"])
+						self:SetSetting("SizeX")
+
+						self:SetMode(self.MODE_ADJUSTING)
+						self:SetMinMaxValues(1, 2000)
+						self:SetRange(20)
+						self:SetValueStep(0.1)
+						self:SetWheelStep(1)
+						
+						self:SetTextFormatter(TMW.C.Formatter.F_1, TMW.C.Formatter.F_0)
+					</OnLoad>
+				</Scripts>
+			</Slider>
+
+			<Slider parentKey="SizeY" inherits="TellMeWhen_SliderTemplate">
+				<Anchors>
+					<Anchor point="TOP" relativeKey="$parent.BorderBar" relativePoint="BOTTOM"  y="-20"/>
+					<Anchor point="LEFT" relativeKey="$parent.BorderBar" />
+					<Anchor point="RIGHT" relativeKey="$parent.BorderBar" />
+					
+				</Anchors>
+				<Scripts>
+					<OnLoad>						
+						TMW:CInit(self)
+
+						self:SetTexts(TMW.L["UIPANEL_BAR_SIZE_Y"], TMW.L["UIPANEL_BAR_SIZE_Y_DESC"])
+						self:SetSetting("SizeY")
+
+						self:SetMode(self.MODE_ADJUSTING)
+						self:SetMinMaxValues(1, 2000)
+						self:SetRange(20)
+						self:SetValueStep(0.1)
+						self:SetWheelStep(1)
+						
+						self:SetTextFormatter(TMW.C.Formatter.F_1, TMW.C.Formatter.F_0)
 					</OnLoad>
 				</Scripts>
 			</Slider>

--- a/Localization/TellMeWhen-enUS.lua
+++ b/Localization/TellMeWhen-enUS.lua
@@ -840,6 +840,10 @@ L["UIPANEL_BAR_BORDERBAR"] = "Bar Border"
 L["UIPANEL_BAR_BORDERBAR_DESC"] = "Set a border around the bar."
 L["UIPANEL_BAR_BORDERCOLOR"] = "Border Color"
 L["UIPANEL_BAR_BORDERCOLOR_DESC"] = "Change the color of the icon and bar borders."
+L["UIPANEL_BAR_SIZE_X"] = "Icon Width"
+L["UIPANEL_BAR_SIZE_X_DESC"] = "Modifies the width of icons in this group."
+L["UIPANEL_BAR_SIZE_Y"] = "Icon Height"
+L["UIPANEL_BAR_SIZE_Y_DESC"] = "Modifies the height of icons in this group."
 
 
 L["UIPANEL_ICONS"] = "Icons"


### PR DESCRIPTION
Added sliders for SizeX and SizeY to group settings. I did some minor re-ordering of the sliders to make room, as well as changed the size of the box. It might be better to actually move it so that X/Y/Width/Hight are on one column and then fill the rest of the space, but that would have required a lot more tweaking of sizes and coordinates and so I went with minimal changes. Might rework if you find it not good enough. 