### PR TITLE
exposing timers for external use

### DIFF
--- a/Components/EventHandlers/Timer/Timer.lua
+++ b/Components/EventHandlers/Timer/Timer.lua
@@ -64,6 +64,7 @@ local TIMERS = setmetatable({}, {__index = function(self, k)
 	return t
 end})
 
+TMW.TIMERS = TIMERS
 
 function Timer:SanitizeTimerName(counter)
 	-- don't return in a single line because that will return all of gsub's return values, which we don't want.


### PR DESCRIPTION
This will allow lua scripts to manage timers. Currently the only way to do this is for LUA scripts to manage counters and then create notification timers based on these counters, which is very laborious. 