### PR TITLE
Updates to CC groups

### DIFF
--- a/Components/Core/Spells/Equivalencies.lua
+++ b/Components/Core/Spells/Equivalencies.lua
@@ -39,28 +39,11 @@ TMW.BE = {
 	debuffs = {
 		ReducedHealing = {
 			 115804, -- Mortal Wounds
-		},
-		CrowdControl = {
-			   -118, -- Polymorph
-			  -6770, -- Sap
-			   -605, -- Mind Control
-			  20066, -- Repentance
-			 -51514, -- Hex (also 211004, 210873, 211015, 211010)
-			  -9484, -- Shackle Undead
-			  -5782, -- Fear
-			  33786, -- Cyclone
-			  -3355, -- Freezing Trap
-			 209790, -- Freezing Arrow (hunter pvp)
-			   -710, -- Banish
-			  -6358, -- Seduction
-			  -2094, -- Blind
-			 -19386, -- Wyvern Sting
-			 -82691, -- Ring of Frost
-			 115078, -- Paralysis
-			 115268, -- Mesmerize
-			 107079, -- Quaking Palm
-			 207685, -- Sigil of Misery (Havoc Demon hunter)
-			 198909, -- Song of Chi-ji (mistweaver monk talent)
+			  27580, -- Sharpen Blade
+			 195452, -- Nightblade
+			   8679, -- Wound Poison
+			 115625, -- Mortal Cleave
+			  30213, -- Legion Strike
 		},
 		Shatterable = {
 			    122, -- Frost Nova
@@ -316,7 +299,6 @@ TMW.BE = {
 		DefensiveBuffsAOE = {
 			 -62618, -- Power Word: Barrier
 			 -31821, -- Aura Mastery
-			 -76577, -- Smoke Bomb
 			 -51052, -- Anti-Magic Zone
 			 204150, -- Aegis of light (prot pally talent)
 			 204335, -- Aegis of light (prot pally talent)
@@ -356,7 +338,6 @@ TMW.BE = {
 			  61336, -- Survival Instincts
 		},
 		DamageBuffs = {
-			  12292, -- Bloodbath
 			   1719, -- Battle Cry
 			  12472, -- Icy Veins
 			  51271, -- Pillar of Frost
@@ -404,7 +385,7 @@ TMW.BE = {
 			  31224, -- Cloak of Shadows
 			   8178, -- Grounding Totem Effect
 			    710, -- Banish
-		     204018, -- Blessing of Spellwarding
+		   	 204018, -- Blessing of Spellwarding
 		},
 		BurstHaste = {
 			  90355, -- Ancient Hysteria
@@ -415,8 +396,8 @@ TMW.BE = {
 			  80353, -- Time Warp
 			 160452, -- Netherwinds
 			  32182, -- Heroism,
-			  264667, -- Primal Rage
-			  256740, -- Drums of the Maelstrom
+			 264667, -- Primal Rage
+			 256740, -- Drums of the Maelstrom
 		},
 	},
 	casts = {

--- a/Components/Core/Spells/Equivalencies.lua
+++ b/Components/Core/Spells/Equivalencies.lua
@@ -92,16 +92,15 @@ TMW.BE = {
 			   5246, -- Intimidating Shout
 			  87204, -- Sin and Punishment
 			  -8122, -- Psychic Scream
+			  -6789, -- Mortal Coil
 			 207685, -- Sigil of Misery (Havoc Demon hunter)
 		},
 		Incapacitated = {
 			     99, -- Incapacitating Roar
-			   3355, -- Freezing Trap
-			 209790, -- Freezing Arrow (diamond ice)
+			  -3355, -- Freezing Trap
 			  -6770, -- Sap
 			   -118, -- Polymorph
 			 115268, -- Mesmerize
-			  -6789, -- Mortal Coil
 			 -51514, -- Hex (also 211015; 211010; 211004; 210873; 196942; 269352; 277778; 277784)
 			  20066, -- Repentance
 			 200196, -- Holy Word: Chastise

--- a/Components/Core/Spells/Equivalencies.lua
+++ b/Components/Core/Spells/Equivalencies.lua
@@ -97,24 +97,24 @@ TMW.BE = {
 		},
 		Incapacitated = {
 			     99, -- Incapacitating Roar
-			  -3355, -- Freezing Trap
-			  -6770, -- Sap
 			   -118, -- Polymorph
-			 115268, -- Mesmerize
-			 -51514, -- Hex (also 211015; 211010; 211004; 210873; 196942; 269352; 277778; 277784)
-			  20066, -- Repentance
-			 200196, -- Holy Word: Chastise
-			  82691, -- Ring of Frost
 			   2637, -- Hibernate
 			   1776, -- Gouge
+			  -3355, -- Freezing Trap
+			  -6358, -- Seduction
+			  -6770, -- Sap
+			 -19386, -- Wyvern Sting
+			  20066, -- Repentance
+			 -51514, -- Hex (also 211015; 211010; 211004; 210873; 196942; 269352; 277778; 277784)
+			  82691, -- Ring of Frost
+			 107079, -- Quaking Palm
+			 115078, -- Paralysis
+			 115268, -- Mesmerize
+			 197214, -- Sundering
+			 200196, -- Holy Word: Chastise
+			 203126, -- Maim (with blood trauma feral pvp talent
 			 217832, -- Imprison
 			 221527, -- Imprison
-			  -6358, -- Seduction
-			 -19386, -- Wyvern Sting
-			 115078, -- Paralysis
-			 197214, -- Sundering
-			 107079, -- Quaking Palm
-			 203126, -- Maim (with blood trauma feral pvp talent)
 			 226943, -- Mind Bomb
 		},
 		Disoriented = {
@@ -122,22 +122,22 @@ TMW.BE = {
 			  31661, -- Dragon's Breath
 			 105421, -- Blinding light (paladin talent)
 			 186387, -- Bursting Shot (hunter marks ability)
+			 198909, -- Song of Chi-ji (mistweaver monk talent)
 			 202274, -- Incendiary brew (brewmaster monk pvp talent)
 			 207167, -- Blinding Sleet (dk talent)
 			 213691, -- Scatter Shot (hunter pvp talent)
-			 198909, -- Song of Chi-ji (mistweaver monk talent)
 		},
 		Silenced = {
-			 -15487, -- Silence
 			  -1330, -- Garrote - Silence
-			  31935, -- Avenger's Shield
-			 -78675, -- Solar Beam
-			 217824; -- Shield of Virtue
-			 202933, -- Spider Sting
-			 199683, -- Last Word
-			 -47476, -- Strangulate
+			 -15487, -- Silence
 			  31117, -- Unstable Affliction
+			  31935, -- Avenger's Shield
+			 -47476, -- Strangulate
+			 -78675, -- Solar Beam
+			 199683, -- Last Word
+			 202933, -- Spider Sting
 			 204490, -- Sigil of Silence
+			 217824; -- Shield of Virtue
 		},
 		Rooted = {
 			   -339, -- Entangling Roots
@@ -307,161 +307,161 @@ TMW.BE = {
 			-276112, -- Divine Steed
 		},
 		ImmuneToStun = {
-			  33786, -- Cyclone
-			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
-			 186265, -- Aspect of the Turtle
-			  48792, -- Icebound Fortitude
-			 213610, -- Holy Ward
-			  46924, -- Bladestorm (fury)
-			 227847, -- Bladestorm (arms)
-			    710, -- Banish
-			   6615, -- Free Action
-			  45438, -- Ice Block
 			    642, -- Divine Shield
+			    710, -- Banish
 			   1022, -- Blessing of Protection
+			   6615, -- Free Action
+			  33786, -- Cyclone
+			  45438, -- Ice Block
+			  46924, -- Bladestorm (fury)
+			  48792, -- Icebound Fortitude
+			 186265, -- Aspect of the Turtle
+			 213610, -- Holy Ward
+			 227847, -- Bladestorm (arms)
+			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
 		},
 		DefensiveBuffsAOE = {
-			 -62618, -- Power Word: Barrier
 			 -31821, -- Aura Mastery
-			-209426, -- Darkness
-			 201633, -- Earthen Wall
 			 -51052, -- Anti-Magic Zone
+			 -62618, -- Power Word: Barrier
+			 201633, -- Earthen Wall
 			 204150, -- Aegis of light (prot pally talent)
 			 204335, -- Aegis of light (prot pally talent)
+			-209426, -- Darkness
 		},
 		DefensiveBuffsSingle = {
-			  47788, -- Guardian Spirit
-			  31850, -- Ardent Defender
-			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
-			  23920, -- Spell Reflection
+			    498, -- Divine Protection
+			    642, -- Divine Shield
 			    871, -- Shield Wall
-			 118038, -- Die by the Sword
-			  48707, -- Anti-Magic Shell
-			 104773, -- Unending Resolve
-			   6940, -- Blessing of Sacrifice
-			 108271, -- Astral Shift
-			 210918, -- Ethereal Form (shaman PVP talent)
+			   1022, -- Blessing of Protection
 			   5277, -- Evasion
+			   6940, -- Blessing of Sacrifice
+			  22812, -- Barkskin
+			  23920, -- Spell Reflection
+			  31224, -- Cloak of Shadows
+			  31850, -- Ardent Defender
+			  33206, -- Pain Suppression
+			  45438, -- Ice Block
+			  47585, -- Dispersion
+			  47788, -- Guardian Spirit
+			  48707, -- Anti-Magic Shell
+			  48792, -- Icebound Fortitude
+			  61336, -- Survival Instincts
+			  86659, -- Guardian of Ancient Kings
 			 102342, -- Ironbark
+			 104773, -- Unending Resolve
+			 108271, -- Astral Shift
+			 113862, -- Greater Invisibility
+			 115176, -- Zen Meditation
+			 115203, -- Fortifying Brew
+			 118038, -- Die by the Sword
+			 122278, -- Dampen Harm
+			 122783, -- Diffuse Magic
 			 155835, -- Bristling Fur
 			 184364, -- Enraged Regeneration
-			   1022, -- Blessing of Protection
-			  31224, -- Cloak of Shadows
-			  33206, -- Pain Suppression
-			  47585, -- Dispersion
-			 186265, -- Aspect of the Turtle
-			  48792, -- Icebound Fortitude
-			 115176, -- Zen Meditation
-			 122783, -- Diffuse Magic
-			  86659, -- Guardian of Ancient Kings
-			    642, -- Divine Shield
-			  45438, -- Ice Block
-			    498, -- Divine Protection
-			 115203, -- Fortifying Brew
-			  22812, -- Barkskin
-			 122278, -- Dampen Harm
-			 113862, -- Greater Invisibility
-			  61336, -- Survival Instincts
+			 186265, -- Aspect of the Turtle		 
+			 210918, -- Ethereal Form (shaman PVP talent)
+			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
 		},
 		DamageBuffs = {
 			   1719, -- Recklessness
+			   5217, -- Tiger's Fury
+			  12042, -- Arcane Power			   
 			  12472, -- Icy Veins
-			 198144, -- Ice Form
-			 190319, -- Combustion
-			  12042, -- Arcane Power
-			 212283, -- Symbols of Death
-			 185422, -- Shadow Dance
-			  13750, -- Adrenaline Rush
-			 102543, -- Incarnation: King of the Jungle
-			 102560, -- Incarnation: Chosen of Elune
-			 106951, -- Berserk
-			 152173, -- Serenity
-			 137639, -- Storm, Earth, and Fire
-			 193526, -- Trueshot
-			  19574, -- Bestial Wrath
-			 266779, -- Coordinated Assault
-			  51271, -- Pillar of Frost
-			 113858, -- Dark Soul: Instability
-			 113860, -- Dark Soul: Misery
-			 194249, -- Voidform
-			 162264, -- Metamorphosis
+			  13750, -- Adrenaline Rush			  
+			  19574, -- Bestial Wrath	
 			  31884, -- Avenging Wrath
-			-107574, -- Avatar
+			  51271, -- Pillar of Frost	
+			 102543, -- Incarnation: King of the Jungle
+			 102560, -- Incarnation: Chosen of Elune			  
+			 106951, -- Berserk
+			-107574, -- Avatar	
+			 113858, -- Dark Soul: Instability
+			 113860, -- Dark Soul: Misery						
 			 114050, -- Ascendance
 			 114051, -- Ascendance
-			   5217, -- Tiger's Fury
+			 137639, -- Storm, Earth, and Fire			 
+			 152173, -- Serenity
+			 162264, -- Metamorphosis			 
+			 185422, -- Shadow Dance			 
+			 190319, -- Combustion			 
+			 193526, -- Trueshot			
+			 194249, -- Voidform
+			 198144, -- Ice Form
+			 212283, -- Symbols of Death
 			 262228, -- Deadly Calm
+			 266779, -- Coordinated Assault
 		},
 		MiscHelpfulBuffs = {
 			   1044, -- Blessing of Freedom
-			  23920, -- Spell Reflection
-			  10060, -- Power Infusion
+			   1850, -- Dash			   
 			   2983, -- Sprint
-			  45182, -- Cheating Death
+			  10060, -- Power Infusion
+			  23920, -- Spell Reflection
 			  31821, -- Aura Mastery
-			  68992, -- Darkflight
+			  45182, -- Cheating Death
 			  53271, -- Master's Call
-			   1850, -- Dash
+			  68992, -- Darkflight
 		},
 		DamageShield = {
+			    -17, -- Power Word: Shield
+			   1463, -- Incanter's Flow
+			 -11426, -- Ice Barrier
+			  77535, -- Blood Shield
 			 114908, -- Spirit Shell
 			 108008, -- Indomitable
-			   1463, -- Incanter's Flow
-			 173260, -- Shieldtronic Shield
 			 108366, -- Soul Leech
-			 184662, -- Shield of Vengeance
-			 227225, -- Soul Barrier
-			 169373, -- Boulder Shield
-			 152118, -- Clarity of Will 
-			 274346, -- Soulmonger (DH azerite talent)
-			 274289, -- Burning Soul (DH azerite talent)
-			 145441, -- Yu'lon's Barrier
-			 235450, -- Prismatic Barrier
-			 235313, -- Blazing Barrier
 			 108416, -- Dark Pact
-			 -11426, -- Ice Barrier
-			    -17, -- Power Word: Shield
-			  77535, -- Blood Shield
 			 116849, -- Life Cocoon
+			 145441, -- Yu'lon's Barrier
+			 152118, -- Clarity of Will 
+			 169373, -- Boulder Shield
+			 173260, -- Shieldtronic Shield
+			 184662, -- Shield of Vengeance
 			 194022, -- Mental Fortitude (Shadow Priest Artifact)
+			 227225, -- Soul Barrier
+			 235313, -- Blazing Barrier
+			 235450, -- Prismatic Barrier
 			 269279, -- Resounding Protection (general azerite talent)
 			 270657, -- Bulwark of the Masses (general azerite talent)
+			 274289, -- Burning Soul (DH azerite talent)
+			 274346, -- Soulmonger (DH azerite talent)
 			 280212, -- Bury the Hatchet (warrior azerite talent, phys absorb only)
 		},
 		ImmuneToMagicCC = {
-			  33786, -- Cyclone
-			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
-			 186265, -- Aspect of the Turtle
-			  23920, -- Spell Reflection
-			  46924, -- Bladestorm (fury)
-			 227847, -- Bladestorm (arms)
-			  48707, -- Anti-Magic Shell
-			  45438, -- Ice Block
 			    642, -- Divine Shield
-			  31224, -- Cloak of Shadows
-			   8178, -- Grounding Totem Effect
-			 213915, -- Mass Spell Reflection
 			    710, -- Banish
+			   8178, -- Grounding Totem Effect
+			  23920, -- Spell Reflection
+			  31224, -- Cloak of Shadows
+			  33786, -- Cyclone
+			  45438, -- Ice Block
+			  46924, -- Bladestorm (fury)
+			  48707, -- Anti-Magic Shell
+			 186265, -- Aspect of the Turtle
 		   	 204018, -- Blessing of Spellwarding
+			 213915, -- Mass Spell Reflection
+			 227847, -- Bladestorm (arms)
+			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
 		},
 		BurstHaste = {
+			   2825, -- Bloodlust
+			  32182, -- Heroism,
+			  80353, -- Time Warp
 			  90355, -- Ancient Hysteria
 			 146555, -- Drums of Rage
 			 178207, -- Drums of Fury
-			 230935, -- Drums of the Mountain
-			   2825, -- Bloodlust
-			  80353, -- Time Warp
 			 160452, -- Netherwinds
-			  32182, -- Heroism,
-			 264667, -- Primal Rage
+			 230935, -- Drums of the Mountain
 			 256740, -- Drums of the Maelstrom
+			 264667, -- Primal Rage
 		},
 	},
 	casts = {
 		Heals = {
-			   2061, -- Flash Heal
 			    596, -- Prayer of Healing
 			   2060, -- Heal
+			   2061, -- Flash Heal
 			  32546, -- Binding Heal
 			  33076, -- Prayer of Mending
 			  64843, -- Divine Hymn
@@ -493,17 +493,16 @@ TMW.BE = {
 
 		},
 		PvPSpells = {
-			    339, -- Entangling Roots
-			  33786, -- Cyclone
-			   5782, -- Fear
-			   -605, -- Mind Control
-			  51514, -- Hex
-			  20066, -- Repentance
-			    982, -- Revive Pet
-			  12051, -- Evocation
 			    118, -- Polymorph
-			   5484, -- Howl of Terror
+			    339, -- Entangling Roots
+			   -605, -- Mind Control
+			    982, -- Revive Pet
+			   5782, -- Fear
+			  12051, -- Evocation
 			  20484, -- Rebirth
+			  20066, -- Repentance
+			  33786, -- Cyclone
+			 -51514, -- Hex
 		},
 	},
 }

--- a/Components/Core/Spells/Equivalencies.lua
+++ b/Components/Core/Spells/Equivalencies.lua
@@ -45,6 +45,28 @@ TMW.BE = {
 			 115625, -- Mortal Cleave
 			  30213, -- Legion Strike
 		},
+		CrowdControl = {
+			   -118, -- Polymorph
+			  -6770, -- Sap
+			   -605, -- Mind Control
+			  20066, -- Repentance
+			 -51514, -- Hex (also 211004, 210873, 211015, 211010)
+			  -9484, -- Shackle Undead
+			  -5782, -- Fear
+			  33786, -- Cyclone
+			  -3355, -- Freezing Trap
+			 209790, -- Freezing Arrow (hunter pvp)
+			   -710, -- Banish
+			  -6358, -- Seduction
+			  -2094, -- Blind
+			 -19386, -- Wyvern Sting
+			 -82691, -- Ring of Frost
+			 115078, -- Paralysis
+			 115268, -- Mesmerize
+			 107079, -- Quaking Palm
+			 207685, -- Sigil of Misery (Havoc Demon hunter)
+			 198909, -- Song of Chi-ji (mistweaver monk talent)
+		},
 		Shatterable = {
 			    122, -- Frost Nova
 			 -82691, -- Ring of Frost

--- a/Components/Core/Spells/Equivalencies.lua
+++ b/Components/Core/Spells/Equivalencies.lua
@@ -84,49 +84,51 @@ TMW.BE = {
 		},
 		Feared = {
 			  -5782, -- Fear
-			  -5484, -- Howl of Terror
 			   5246, -- Intimidating Shout
-			  -6789, -- Mortal Coil
-			 -87204, -- Sin and Punishment
+			  87204, -- Sin and Punishment
 			  -8122, -- Psychic Scream
 			 207685, -- Sigil of Misery (Havoc Demon hunter)
 		},
 		Incapacitated = {
 			     99, -- Incapacitating Roar
 			   3355, -- Freezing Trap
-			 209790, -- Freezing Arrow (hunter pvp)
+			 209790, -- Freezing Arrow (diamond ice)
 			  -6770, -- Sap
 			   -118, -- Polymorph
 			 115268, -- Mesmerize
-			 -51514, -- Hex (also 211004, 210873, 211015, 211010)
+			  -6789, -- Mortal Coil
+			 -51514, -- Hex (also 211015; 211010; 211004; 210873; 196942; 269352; 277778; 277784)
 			  20066, -- Repentance
 			 200196, -- Holy Word: Chastise
 			  82691, -- Ring of Frost
+			   2637, -- Hibernate
 			   1776, -- Gouge
+			 217832, -- Imprison
+			 221527, -- Imprison
 			  -6358, -- Seduction
 			 -19386, -- Wyvern Sting
 			 115078, -- Paralysis
-			  31661, -- Dragon's Breath
+			 197214, -- Sundering
 			 107079, -- Quaking Palm
-			 198909, -- Song of Chi-ji (mistweaver monk talent)
 			 203126, -- Maim (with blood trauma feral pvp talent)
 			 226943, -- Mind Bomb
 		},
 		Disoriented = {
 			  -2094, -- Blind
 			  31661, -- Dragon's Breath
-			 105421, -- Bliding light (paladin talent)
+			 105421, -- Blinding light (paladin talent)
 			 186387, -- Bursting Shot (hunter marks ability)
 			 202274, -- Incendiary brew (brewmaster monk pvp talent)
 			 207167, -- Blinding Sleet (dk talent)
 			 213691, -- Scatter Shot (hunter pvp talent)
+			 198909, -- Song of Chi-ji (mistweaver monk talent)
 		},
 		Silenced = {
 			 -15487, -- Silence
-			 -25046, -- Arcane Torrent
 			  -1330, -- Garrote - Silence
 			  31935, -- Avenger's Shield
 			 -78675, -- Solar Beam
+			 217824; -- Shield of Virtue
 			 202933, -- Spider Sting
 			 199683, -- Last Word
 			 -47476, -- Strangulate
@@ -149,12 +151,16 @@ TMW.BE = {
 			 157997, -- Ice Nova (frost mage talent)
 			 162480, -- Steel Trap (hunter talent)
 			 190927, -- harpoon (survival hunter)
+			 198121, -- Frostbite
 			 199042, -- Thunderstruck (Warrior PVP)
 			 200108, -- Ranger's Net (Hunter talent)
 			 201158, -- Super Sticky Tar (Expert Trapper, Hunter talent, Tar Trap effect)
 			 204085, -- Deathchill (DK PVP)
+			 207171, -- Winter is Coming
 			 212638, -- tracker's net (hunter PvP )
 			 228600, -- glacial spike (frost mage talent)
+			 233395, -- Frozen Center
+			 233582, -- Entrenched in Flames
 		},
 		Slowed = {
 			   -116, -- Frostbolt
@@ -219,19 +225,18 @@ TMW.BE = {
 			 210979, -- Focus in the light (holy priest artifact trait)
 		},
 		Stunned = {
-			  -1833, -- Cheap Shot
 			    -25, -- Stun
 			   -408, -- Kidney Shot
 			   -853, -- Hammer of Justice
+			  -1833, -- Cheap Shot
 			   5211, -- Mighty Bash
 			  -7922, -- Warbringer
 			  24394, -- Intimidation
-			  64044, -- Psychic Horror
-			  91797, -- Monstrous Blow
 			 -20549, -- War Stomp
 			  22703, -- Summon Infernal
 			 -30283, -- Shadowfury
 			 -89766, -- Axe Toss
+			  91797, -- Monstrous Blow
 			 -91800, -- Gnaw
 			 108194, -- Asphyxiate (death knight, talent for unholy)
 			 118345, -- Pulverize
@@ -242,18 +247,20 @@ TMW.BE = {
 			 132169, -- Storm Bolt
 			 163505, -- Rake
 			 179057, -- Chaos Nova
-			 196958, -- Strike from the Shadows
 			 199804, -- Between the Eyes
-			 200166, -- Metamorphosis
+			 199085, -- Warpath
 			 200200, -- Holy Word: Chastise
+			 202244, -- Overrun
+			 202346, -- Double Barrel
 			 203123, -- Maim
-			 204399, -- Earthfury (enhancement shaman pvp talent)
+			 204399, -- Earthfury (elemental shaman pvp talent)
+			 204437, -- ightning Lasso
+			 205629, -- Demonic Trample
 			 205630, -- Illidan's Grasp (demon hunter vengeance pvp talent - primary effect)
 			 208618, -- Illidan's Grasp (demon hunter vengeance pvp talent - throw effect)
-			 207165, -- Abomination's Might
-			 207171, -- Winter is Coming
 			 211881, -- Fel Eruption
 			 221562, -- Asphyxiate (death knight, baseline for blood)
+			 255723, -- Bull Rush
 		},
 	},
 	buffs = {

--- a/Components/Core/Spells/Equivalencies.lua
+++ b/Components/Core/Spells/Equivalencies.lua
@@ -270,7 +270,7 @@ TMW.BE = {
 	buffs = {
 		SpeedBoosts = {
 			  -2983, -- Sprint
-			   2379, -- Speed
+			  -2379, -- Speed
 			   2645, -- Ghost Wolf
 			   7840, -- Swim Speed
 			  36554, -- Shadowstep
@@ -278,7 +278,6 @@ TMW.BE = {
 			  58875, -- Spirit Walk
 			 -65081, -- Body and Soul
 			  68992, -- Darkflight
-			  85499, -- Speed of Light
 			  87023, -- Cauterize
 			 -61684, -- Dash
 			 -77761, -- Stampeding Roar
@@ -288,29 +287,33 @@ TMW.BE = {
 			 118922, -- Posthaste
 			 119085, -- Chi Torpedo
 			 121557, -- Angelic Feather
-			 137452, -- Displacer Beast
-			 137573, -- Burst of Speed
+			 188024, -- Skystep Potion
 			 192082, -- Wind Rush (shaman wind rush totem talent)
 			 196674, -- Planewalker (warlock artifact trait)
 			 197023, -- Cut to the chase (rogue pvp talent)
 			 199407, -- Light on your feet (mistweaver monk artifact trait)
-			 201233, -- whirling kicks (windwalaker monk pvp talent)
-			 201447, -- Ride the wind (windwalaker monk pvp talent)
+			 201233, -- whirling kicks (windwalker monk pvp talent)
+			 201447, -- Ride the wind (windwalker monk pvp talent)
+			 202164, -- Bounding Stride (warrior talent)
 			 209754, -- Boarding Party (rogue pvp talent)
 			 210980, -- Focus in the light (holy priest artifact trait)
-			 213177, -- swift as a coursing river (brewmaster artifact trait)
+			 213177, -- Swift as a Coursing River (brewmaster artifact trait)
 			 214121, -- Body and Mind (priest talent)
 			 215572, -- Frothing Berserker (warrior talent)
 			 231390, -- Trailblazer (hunter talent)
 			-186257, -- Aspect of the Cheetah
 			-204475, -- Windburst (marks hunter artifact ability)
+			 250878, -- Lightfoot Potion
+			-276112, -- Divine Steed
 		},
 		ImmuneToStun = {
 			  33786, -- Cyclone
-			 -19263, -- Deterrence
+			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
+			 186265, -- Aspect of the Turtle
 			  48792, -- Icebound Fortitude
-			  46924, -- Bladestorm
-			 227847, -- Bladestorm again?
+			 213610, -- Holy Ward
+			  46924, -- Bladestorm (fury)
+			 227847, -- Bladestorm (arms)
 			    710, -- Banish
 			   6615, -- Free Action
 			  45438, -- Ice Block
@@ -320,14 +323,16 @@ TMW.BE = {
 		DefensiveBuffsAOE = {
 			 -62618, -- Power Word: Barrier
 			 -31821, -- Aura Mastery
+			-209426, -- Darkness
+			 201633, -- Earthen Wall
 			 -51052, -- Anti-Magic Zone
 			 204150, -- Aegis of light (prot pally talent)
 			 204335, -- Aegis of light (prot pally talent)
 		},
 		DefensiveBuffsSingle = {
-			 114030, -- Vigilance
 			  47788, -- Guardian Spirit
 			  31850, -- Ardent Defender
+			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
 			  23920, -- Spell Reflection
 			    871, -- Shield Wall
 			 118038, -- Die by the Sword
@@ -335,15 +340,16 @@ TMW.BE = {
 			 104773, -- Unending Resolve
 			   6940, -- Blessing of Sacrifice
 			 108271, -- Astral Shift
+			 210918, -- Ethereal Form (shaman PVP talent)
 			   5277, -- Evasion
 			 102342, -- Ironbark
 			 155835, -- Bristling Fur
+			 184364, -- Enraged Regeneration
 			   1022, -- Blessing of Protection
-			  74001, -- Combat Readiness
 			  31224, -- Cloak of Shadows
 			  33206, -- Pain Suppression
 			  47585, -- Dispersion
-			 -19263, -- Deterrence
+			 186265, -- Aspect of the Turtle
 			  48792, -- Icebound Fortitude
 			 115176, -- Zen Meditation
 			 122783, -- Diffuse Magic
@@ -351,7 +357,6 @@ TMW.BE = {
 			    642, -- Divine Shield
 			  45438, -- Ice Block
 			    498, -- Divine Protection
-			 157913, -- Evanesce
 			 115203, -- Fortifying Brew
 			  22812, -- Barkskin
 			 122278, -- Dampen Harm
@@ -359,14 +364,33 @@ TMW.BE = {
 			  61336, -- Survival Instincts
 		},
 		DamageBuffs = {
-			   1719, -- Battle Cry
+			   1719, -- Recklessness
 			  12472, -- Icy Veins
+			 198144, -- Ice Form
+			 190319, -- Combustion
+			  12042, -- Arcane Power
+			 212283, -- Symbols of Death
+			 185422, -- Shadow Dance
+			  13750, -- Adrenaline Rush
+			 102543, -- Incarnation: King of the Jungle
+			 102560, -- Incarnation: Chosen of Elune
+			 106951, -- Berserk
+			 152173, -- Serenity
+			 137639, -- Storm, Earth, and Fire
+			 193526, -- Trueshot
+			  19574, -- Bestial Wrath
+			 266779, -- Coordinated Assault
 			  51271, -- Pillar of Frost
+			 113858, -- Dark Soul: Instability
+			 113860, -- Dark Soul: Misery
+			 194249, -- Voidform
+			 162264, -- Metamorphosis
 			  31884, -- Avenging Wrath
 			-107574, -- Avatar
 			 114050, -- Ascendance
 			 114051, -- Ascendance
 			   5217, -- Tiger's Fury
+			 262228, -- Deadly Calm
 		},
 		MiscHelpfulBuffs = {
 			   1044, -- Blessing of Freedom
@@ -385,26 +409,38 @@ TMW.BE = {
 			   1463, -- Incanter's Flow
 			 173260, -- Shieldtronic Shield
 			 108366, -- Soul Leech
+			 184662, -- Shield of Vengeance
+			 227225, -- Soul Barrier
 			 169373, -- Boulder Shield
-			 152118, -- Clarity of Will
+			 152118, -- Clarity of Will 
+			 274346, -- Soulmonger (DH azerite talent)
+			 274289, -- Burning Soul (DH azerite talent)
 			 145441, -- Yu'lon's Barrier
+			 235450, -- Prismatic Barrier
+			 235313, -- Blazing Barrier
 			 108416, -- Dark Pact
 			 -11426, -- Ice Barrier
 			    -17, -- Power Word: Shield
 			  77535, -- Blood Shield
 			 116849, -- Life Cocoon
-			 194022 --- Mental Fortitude (Shadow Priest Artifact)
+			 194022, -- Mental Fortitude (Shadow Priest Artifact)
+			 269279, -- Resounding Protection (general azerite talent)
+			 270657, -- Bulwark of the Masses (general azerite talent)
+			 280212, -- Bury the Hatchet (warrior azerite talent, phys absorb only)
 		},
 		ImmuneToMagicCC = {
 			  33786, -- Cyclone
-			 -19263, -- Deterrence
+			-228049, -- Guardian of the Forgotten Queen (spellID might be wrong?)
+			 186265, -- Aspect of the Turtle
 			  23920, -- Spell Reflection
-			  46924, -- Bladestorm
+			  46924, -- Bladestorm (fury)
+			 227847, -- Bladestorm (arms)
 			  48707, -- Anti-Magic Shell
 			  45438, -- Ice Block
 			    642, -- Divine Shield
 			  31224, -- Cloak of Shadows
 			   8178, -- Grounding Totem Effect
+			 213915, -- Mass Spell Reflection
 			    710, -- Banish
 		   	 204018, -- Blessing of Spellwarding
 		},


### PR DESCRIPTION
I'd also suggest further changes/consolidations. Not sure what the "Crowd Control" group is for,  it's just a bunch of random spells that exist in another groups as is. Might also consider changing all groups for CC related debuffs into groups by their own DR instead of by the specific name of the CC (IE combine fear and disorient tables, because both share the same DR). 