### PR TITLE
Fixed luavalue icon type to work with secret tainted values.

### DIFF
--- a/Components/IconTypes/IconType_luavalue/luavalue.lua
+++ b/Components/IconTypes/IconType_luavalue/luavalue.lua
@@ -49,17 +49,9 @@ local function LuaValue_OnUpdate(icon)
 	value = tonumber(value)
 	maxValue = tonumber(maxValue)
 
-	if value == nil or maxValue == nil or maxValue < 0 then
+	if value == nil or maxValue == nil then
 		icon:SetInfo("state", STATE_FAIL)
 		return
-	end
-
-	if value < 0 then
-		value = 0
-	end
-
-	if value > maxValue then
-		maxValue = value
 	end
 
 	icon:SetInfo("state; value, maxValue, valueColor, valueCurveFunc", STATE_SUCCEED, value, maxValue, BarColors, valueCurveFunc)


### PR DESCRIPTION
I previously contributed the luavalue icon type.

I removed the boundary checks from the luavalue onUpdate function to avoid errors with secret tainted values. Out of bounds values won't break the icon. 

I'm not sure the valueCurveFunc is relevant for this icon type. Should the help text be updated?.