### PR TITLE
AddonSentry: fix WoW API validation errors

### DIFF
--- a/Scripts/Currencies.lua
+++ b/Scripts/Currencies.lua
@@ -1,4 +1,4 @@
-{
+return {
 	61,	--Dalaran Jewelcrafter's Token
 	81,	--Epicurean's Award
 	241,	--Champion's Seal

--- a/build/WeaponAugments.lua
+++ b/build/WeaponAugments.lua
@@ -1,4 +1,4 @@
-{	12404, -- Dense Sharpening Stone
+return {	12404, -- Dense Sharpening Stone
 	124674, -- Day-Old Darkmoon Doughnut
 	12643, -- Dense Weightstone
 	171285, -- Shadowcore Oil


### PR DESCRIPTION
🛡️ **AddonSentry found and fixed WoW API validation errors in your addon.**

AddonSentry validates addon Lua against the live World of Warcraft API for each game build. Scanning this repository against **Mainline (build 120007)** surfaced errors that this pull request fixes:

Both files are bare table literals causing 'expected statement'/'Unexpected exp' errors. Prefixed each table with 'return ' so the file returns the table as a module value, resolving the findings while preserving the data.

Validation errors: **2496 → 2491** with this change.

**Edits:**
- `Scripts/Currencies.lua` — A bare table literal at file scope is not a valid statement; returning it makes the file a valid module that yields the table.
- `build/WeaponAugments.lua` — A bare table literal at file scope is not a valid statement; returning it makes the file a valid module that yields the table.

This PR was opened automatically by [AddonSentry](https://github.com/apps/addonsentry). Install the free GitHub App to catch issues like these on every pull request — and the moment Blizzard ships a patch that changes the API.

<sub>Automated outreach. The fixes are AI-generated — please review before merging.</sub>

_Not interested? Reply **`opt out`** on this thread and AddonSentry will never open another pull request or issue on your repositories._